### PR TITLE
chore: use go-winio for dialing pipes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module seelocaltime
 
 go 1.24.2
+
+require github.com/Microsoft/go-winio v0.6.2
+
+require golang.org/x/sys v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func NewDiscordRPC(clientID string) *DiscordRPC {
 func (d *DiscordRPC) Connect() error {
 	for i := 0; i < 10; i++ {
 		pipePath := d.getPipePath(i)
-		conn, err := net.Dial("unix", pipePath)
+		conn, err := dialPipe(pipePath)
 		if err == nil {
 			d.conn = conn
 			return d.handshake()

--- a/pipe_unix.go
+++ b/pipe_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package main
+
+import (
+	"net"
+)
+
+func dialPipe(pipePath string) (net.Conn, error) {
+	return net.Dial("unix", pipePath)
+}

--- a/pipe_windows.go
+++ b/pipe_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package main
+
+import (
+	"github.com/Microsoft/go-winio"
+	"net"
+)
+
+func dialPipe(pipePath string) (net.Conn, error) {
+	// because simple things are a pain in Windows
+	return winio.DialPipe(pipePath, nil)
+}


### PR DESCRIPTION
## Summary

This PR fixes errors with `net.Dial` on Windows which was preventing Discord connection.
I'm using `github.com/Microsoft/go-winio` package because it was specifically built for this use case.

fixes: #1 